### PR TITLE
コメントのバリデーションエラーを表示

### DIFF
--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -6,7 +6,7 @@ class Books::CommentsController < CommentsController
   def create
     super
     @book = @commentable
-    render 'books/show'
+    @render_file = 'books/show'
   end
 
   private

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -3,6 +3,12 @@
 class Books::CommentsController < CommentsController
   before_action :set_commentable
 
+  def create
+    super
+    @book = @commentable
+    render 'books/show'
+  end
+
   private
 
   def set_commentable

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,10 +2,12 @@
 
 class CommentsController < ApplicationController
   def create
-    @comment = @commentable.comments.new(comment_params)
+    # @comment = @commentable.comments.new(comment_params)
+    @comment = Comment.new
     @comment.user = current_user
-    @comment.save!
-    redirect_to @commentable, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
+    @comment.save
+    # @comment.errors.add(:user, 'must be logged in')
+    # redirect_to @commentable, notice: t('controllers.common.notice_create', name: Comment.model_name.human) if @comment.save
   end
 
   def destroy

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,12 +2,10 @@
 
 class CommentsController < ApplicationController
   def create
-    # @comment = @commentable.comments.new(comment_params)
-    @comment = Comment.new
+    @comment = @commentable.comments.new(comment_params)
     @comment.user = current_user
-    @comment.save
-    # @comment.errors.add(:user, 'must be logged in')
-    # redirect_to @commentable, notice: t('controllers.common.notice_create', name: Comment.model_name.human) if @comment.save
+
+    redirect_to @commentable, notice: t('controllers.common.notice_create', name: Comment.model_name.human) if @comment.save
   end
 
   def destroy

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,7 +5,11 @@ class CommentsController < ApplicationController
     @comment = @commentable.comments.new(comment_params)
     @comment.user = current_user
 
-    redirect_to @commentable, notice: t('controllers.common.notice_create', name: Comment.model_name.human) if @comment.save
+    if @comment.save
+      redirect_to @commentable, notice: t('controllers.common.notice_create', name: Comment.model_name.human)
+    else
+      render @render_file
+    end
   end
 
   def destroy

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -3,6 +3,12 @@
 class Reports::CommentsController < CommentsController
   before_action :set_commentable
 
+  def create
+    super
+    @report = @commentable
+    render 'reports/show'
+  end
+
   private
 
   def set_commentable

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -6,7 +6,7 @@ class Reports::CommentsController < CommentsController
   def create
     super
     @report = @commentable
-    render 'reports/show'
+    @render_file = 'books/show'
   end
 
   private

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -6,7 +6,7 @@ class Reports::CommentsController < CommentsController
   def create
     super
     @report = @commentable
-    @render_file = 'books/show'
+    @render_file = 'reports/show'
   end
 
   private

--- a/app/views/shared/comments/_form.html.erb
+++ b/app/views/shared/comments/_form.html.erb
@@ -1,4 +1,16 @@
 <%= form_with(model: [commentable, comment], local: true) do |form| %>
+  <% if comment.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>
+
+      <ul>
+        <% comment.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <div class="field required">
     <%= form.text_area(:body, { placeholder: Comment.model_name.human, required: true }) %>
   </div>

--- a/app/views/shared/comments/_form.html.erb
+++ b/app/views/shared/comments/_form.html.erb
@@ -1,12 +1,8 @@
 <%= form_with(model: [commentable, comment], local: true) do |form| %>
   <% if comment.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(comment.errors.count, "error") %> prohibited this comment from being saved:</h2>
-
       <ul>
-        <% comment.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
+        <li><%= comment.errors.full_messages_for(:body).first %></li>
       </ul>
     </div>
   <% end %>

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -23,3 +23,5 @@ ja:
         body: 本文
         author: 著者
         posted_at: 投稿日時
+      comment:
+        body: コメントの本文


### PR DESCRIPTION
## 気になっていること
コメントの本文を空 ('' or nil) で保存しようとした時にvalidation エラーが2つ発生しました。
~~`Commentable を入力してください` がなぜ出るのか気になっています。~~ →　以下の予想 https://github.com/yamatatsu10969/fjord-books_app/pull/7#pullrequestreview-957184942

`以下のコミットの時の表示1` の画像のところです。
commentable のところは表示は不要なので `以下のコミットの時の表示2` の表示にしてみました。

## 以下のコミットの時の表示1
https://github.com/yamatatsu10969/fjord-books_app/pull/7/commits/05b3c14e0adfccda58ef588364bd4c84392aa197

<img width="535" alt="CleanShot 2022-04-29 at 10 21 18@2x" src="https://user-images.githubusercontent.com/43805056/165872233-91f2938b-541b-4936-9934-89cd302bc1c4.png">

## 以下のコミットの時の表示2
https://github.com/yamatatsu10969/fjord-books_app/pull/7/commits/31c2134e2323b937a121968aa7c7e08a40c014a9
<img width="662" alt="CleanShot 2022-04-29 at 10 19 21@2x" src="https://user-images.githubusercontent.com/43805056/165872252-0a2e757d-12e5-43c2-96eb-3dd87935d48b.png">

